### PR TITLE
Fix build on Debian and other systems that enable PIE by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@
 all: injector
 
 injector: injector.o
-	$(CC) $(CFLAGS) $< -O3 -Wall -l:libcapstone.a -o $@ -pthread
+	$(CC) $(CFLAGS) -no-pie $< -O3 -Wall -l:libcapstone.a -o $@ -pthread
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $@ -Wall
+	$(CC) $(CFLAGS) -no-pie -c $< -o $@ -Wall
 
 clean:
-	rm *.o injector
+	rm -f *.o injector


### PR DESCRIPTION
Before the patch:

~~~~
$ make clean all
rm -f *.o injector
cc -fPIC -c injector.c -o injector.o -Wall
injector.c:321:93: warning: excess elements in array initializer
  .start={.bytes={0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}, .len=0},
                                                                                             ^~~~
injector.c:321:93: note: (near initialization for ‘total_range.start.bytes’)
injector.c:322:91: warning: excess elements in array initializer
  .end={.bytes={0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff}, .len=0},
                                                                                           ^~~~
injector.c:322:91: note: (near initialization for ‘total_range.end.bytes’)
injector.c: In function ‘inject’:
injector.c:778:2: warning: asm operand 15 probably doesn’t match constraints
  __asm__ __volatile__ ("\
  ^~~~~~~
injector.c:778:2: error: impossible constraint in ‘asm’
make: *** [Makefile:38: injector.o] Error 1
2
~~~~
